### PR TITLE
Prevent duplicate multisig wallet entries in carousel

### DIFF
--- a/blue_modules/storage-context.js
+++ b/blue_modules/storage-context.js
@@ -250,6 +250,7 @@ export const BlueStorageProvider = ({ children }) => {
   };
 
   const addWallet = wallet => {
+    if (BlueApp.wallets.some(w => w.getID() === wallet.getID())) return;
     BlueApp.wallets.push(wallet);
     setWallets([...BlueApp.getWallets()]);
   };


### PR DESCRIPTION
## Summary
- Guard `BlueStorageContext.addWallet` to skip pushing a wallet whose `getID()` already exists in `BlueApp.wallets`.
- Fixes the reported bug where the same multisig wallet appeared multiple times in the wallet carousel under unclear repro steps.

## Why
`MultisigHDWallet.getID()` is deterministic — `sha256(sortedCosigners + ';' + sortedFingerprints)` — so re-running the create flow (`addMultisigStep2.js`) or the import flow (`importMultisignature.tsx`) with the same inputs produces the same ID. Both flows call `addWallet` (not `addAndSaveWallet`), and only `addAndSaveWallet` had a duplicate guard, so duplicates landed in `BlueApp.wallets`. The carousel keyExtractor uses array index, so each duplicate renders as its own card.

Triggers that the one-line guard closes:
- Slow `fetchBalance()` followed by user backing out and re-confirming the create.
- Animated QR (UR) re-firing `onBarScanned` after the decoder/cache reset in `useQrCodeScanner` while the camera is still mounted during `await fetchBalance()`.
- Untreated taps across the clipboard / image / manual-text buttons in the import screen.

Persistent state isn't corrupted: `BlueApp.loadFromDisk` already de-dupes on `getID()` at startup — duplicates were only visible until app restart. This patch keeps the in-session view consistent.

## Test plan
- [ ] Create the same multisig wallet twice via "Add multisig" with identical cosigners → only one entry in the carousel.
- [ ] Import the same multisig descriptor twice via QR / manual text → only one entry in the carousel.
- [ ] Regular wallet creation (`add.js`) still works (HD wallets always have unique IDs, so the guard is a no-op).
- [ ] Onboarding via `importDiscovery.js` still completes (already used `addAndSaveWallet`, unchanged).