### PR TITLE
Fix multisig cosigner match rejecting valid seeds on import (#176 bug 2)

### DIFF
--- a/__mocks__/react-native-config.js
+++ b/__mocks__/react-native-config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/class/multisig-cosigner-match.ts
+++ b/class/multisig-cosigner-match.ts
@@ -1,0 +1,44 @@
+import { MultisigHDWallet } from './wallets/multisig-hd-wallet';
+
+/**
+ * DFX-custom helper for the "import multisig" flow: determines whether a seed (mnemonic + optional
+ * BIP39 passphrase) belongs to one of `wallet`'s cosigners, returning its 1-based index, or -1.
+ *
+ * Kept out of MultisigHDWallet (BlueWallet-derived) so that class stays identical to upstream and
+ * doesn't conflict on fork sync. BlueWallet has no equivalent matcher; the check is DFX-specific.
+ *
+ * Matches by master fingerprint first (robust regardless of derivation path, passphrase or xpub
+ * encoding), then falls back to deriving the xpub at each cosigner's own path with the passphrase —
+ * the same derivation BlueWallet uses internally for cosigners.
+ */
+export function findCosignerIndexForSeed(wallet: MultisigHDWallet, mnemonic?: string, passphrase?: string): number {
+  if (!mnemonic) return -1;
+
+  let fingerprint: string | undefined;
+  try {
+    fingerprint = MultisigHDWallet.mnemonicToFingerprint(mnemonic, passphrase as string);
+  } catch {
+    fingerprint = undefined;
+  }
+
+  const cosigners = wallet.getCosigners();
+  for (let index = 1; index <= cosigners.length; index++) {
+    const cosigner = cosigners[index - 1];
+
+    if (fingerprint && wallet.getFingerprint(index) === fingerprint) return index;
+    if (cosigner === mnemonic) return index;
+    if (!MultisigHDWallet.isXpubString(cosigner)) continue;
+
+    const path = wallet.getCustomDerivationPathForCosigner(index);
+    if (!path) continue;
+
+    try {
+      const derivedXpub = MultisigHDWallet.seedToXpub(mnemonic, path, passphrase);
+      if (MultisigHDWallet.zpubToXpub(cosigner) === MultisigHDWallet.zpubToXpub(derivedXpub)) return index;
+    } catch {
+      // not derivable at this cosigner's path; keep looking
+    }
+  }
+
+  return -1;
+}

--- a/screen/wallets/importMultisignature.tsx
+++ b/screen/wallets/importMultisignature.tsx
@@ -13,6 +13,7 @@ import { useWalletContext } from '../../contexts/wallet.context';
 import loc from '../../loc';
 import { ManualTextModal } from '../../components/ManualTextModal';
 import { MultisigHDWallet } from '../../class/wallets/multisig-hd-wallet';
+import { findCosignerIndexForSeed } from '../../class/multisig-cosigner-match';
 
 const ImportMultisignature: React.FC = () => {
   const { addWallet, saveToDisk, isElectrumDisabled } = useContext(BlueStorageContext);
@@ -46,16 +47,18 @@ const ImportMultisignature: React.FC = () => {
       setQuorum(multisigWallet.getN());
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      const derivationPath = multisigWallet.getDerivationPath();
-      const ownXpub = multisigWallet.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(mainWallet?.getSecret(), derivationPath));
-      const ownZpub = MultisigHDWallet.xpubToZpub(ownXpub);
-      const ownXpubFromZpub = MultisigHDWallet.zpubToXpub(ownZpub);
-      const isPartOfMultisig = multisigWallet.getCosigners().some(cosigner => cosigner === ownXpub || cosigner === ownZpub || cosigner === ownXpubFromZpub || cosigner === mainWallet?.getSecret());
-      if (!isPartOfMultisig) throw new Error(loc.multisig.not_part_of_multisig);
+      const ownSeed = mainWallet?.getSecret();
+      const ownPassphrase = (mainWallet as { getPassphrase?: () => string } | undefined)?.getPassphrase?.();
+      const ownCosignerIndex = findCosignerIndexForSeed(multisigWallet, ownSeed, ownPassphrase); // 1-based, or -1
+      if (ownCosignerIndex === -1) throw new Error(loc.multisig.not_part_of_multisig);
 
       multisigWallet.getCosigners().forEach((cosigner, index) => {
-        if (cosigner === mainWallet?.getSecret()) return;
-        if (cosigner === ownXpub || cosigner === ownZpub || cosigner === ownXpubFromZpub) return multisigWallet.replaceCosignerXpubWithSeed(index + 1, mainWallet?.getSecret() as string, '');
+        if (cosigner === ownSeed) return;
+        if (index + 1 === ownCosignerIndex) {
+          if (MultisigHDWallet.isXpubString(cosigner))
+            multisigWallet.replaceCosignerXpubWithSeed(ownCosignerIndex, ownSeed as string, ownPassphrase || '');
+          return;
+        }
         if (MultisigHDWallet.isXpubForMultisig(cosigner)) return;
         // Then it should be a seed? try to replace it
         multisigWallet.replaceCosignerSeedWithXpub(index + 1);

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { MultisigHDWallet } from '../../class/';
 import { BlueURDecoder, decodeUR, encodeUR } from '../../blue_modules/ur';
 import { MultisigCosigner } from '../../class/multisig-cosigner';
+import { findCosignerIndexForSeed } from '../../class/multisig-cosigner-match';
 const bitcoin = require('bitcoinjs-lib');
 const Base43 = require('../../blue_modules/base43');
 
@@ -2286,5 +2287,79 @@ describe('multisig-cosigner', () => {
     assert.deepStrictEqual(result, [
       'ur:crypto-account/oeadcywehhhpleaolytaadmhtaaddloxaxhdclaoamutctbahthnislelbwemnkeoefnhddienfetbpygrpaqdkemyrywyldaspyjkdtaahdcxhyneskwdhlehlfbwrpdnjlgsgakplkjtknvyttsgolnnlbwlcagoolcpfgsglkinamtaaddyotadlfcsdpykaocywehhhpleaxadaycywehhhplekpdwveih',
     ]);
+  });
+});
+
+describe('multisig cosigner matching for import (issue #176)', () => {
+  const path = "m/48'/0'/0'/2'";
+  const customPath = "m/48'/0'/1'/2'";
+  const seedA = 'salon smoke bubble dolphin powder govern rival sport better arrest certain manual';
+  const seedB = 'chaos word void picture gas update shop wave task blossom close inner';
+  const passA = '9WDdFSZX4d6mPxkr';
+  const strangerSeed = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+  // builds the public, xpub-only config a customer re-imports on a new phone
+  const buildConfig = ({ withPassphrase = false, derivation = path } = {}) => {
+    const source = new MultisigHDWallet();
+    source.setDerivationPath(derivation);
+    source.addCosigner(seedA, undefined, undefined, withPassphrase ? passA : undefined);
+    source.addCosigner(seedB);
+    source.setM(2);
+    const config = new MultisigHDWallet();
+    config.setSecret(source.getXpub()); // coordination setup contains only public keys
+    return config;
+  };
+
+  it('matches a standard cosigner seed and rejects a non-cosigner (scenario 1)', () => {
+    const w = buildConfig();
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedB, undefined), 2);
+    assert.strictEqual(findCosignerIndexForSeed(w, strangerSeed, undefined), -1);
+  });
+
+  it('matches a cosigner whose seed uses a BIP39 passphrase (scenario 2)', () => {
+    const w = buildConfig({ withPassphrase: true });
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, passA), 1);
+    // the historic bug: matching without (or with the wrong) passphrase must NOT succeed
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), -1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, 'wrong-passphrase'), -1);
+  });
+
+  it('matches cosigners registered at different per-cosigner derivation paths (scenario 3)', () => {
+    const w = new MultisigHDWallet();
+    w.setNativeSegwit();
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedA, customPath), MultisigHDWallet.mnemonicToFingerprint(seedA, ''), customPath);
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedB, path), MultisigHDWallet.mnemonicToFingerprint(seedB, ''), path);
+    w.setM(2);
+    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), customPath);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedB, undefined), 2);
+  });
+
+  it('falls back to per-cosigner xpub derivation when no fingerprint is available', () => {
+    // a config whose fingerprints are unknown ('00000000'): fingerprint match cannot work, so
+    // matching must rely on deriving the xpub at each cosigner's own path
+    const w = new MultisigHDWallet();
+    w.setNativeSegwit();
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedA, customPath), '00000000', customPath);
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedB, path), '00000000', path);
+    w.setM(2);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedB, undefined), 2);
+    assert.strictEqual(findCosignerIndexForSeed(w, strangerSeed, undefined), -1);
+  });
+
+  it('matches a cosigner from a sortedmulti() descriptor (empty global path, per-cosigner paths)', () => {
+    const config = buildConfig();
+    const x1 = config.getCosigner(1);
+    const x2 = config.getCosigner(2);
+    const f1 = config.getFingerprint(1);
+    const f2 = config.getFingerprint(2);
+    const descriptor = 'wsh(sortedmulti(2,[' + f1 + '/48h/0h/0h/2h]' + x1 + '/0/*,[' + f2 + '/48h/0h/0h/2h]' + x2 + '/0/*))';
+    const w = new MultisigHDWallet();
+    assert.doesNotThrow(() => w.setSecret(descriptor));
+    assert.strictEqual(w.getN(), 2);
+    assert.strictEqual(w.getDerivationPath(), ''); // descriptors keep an empty global path (as upstream); per-cosigner paths are authoritative
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
   });
 });


### PR DESCRIPTION
## Problem

When a multi-sig customer re-imports their config on a new phone, the cosigner check rejects their seed with **"Your wallet is not part of this multisig setup"** (`loc.multisig.not_part_of_multisig`).

The check in `importMultisignature.tsx` recomputed the seed's xpub **one specific way** — at the wallet-global derivation path, **without the BIP39 passphrase** — then string-compared. It breaks whenever the real cosigner key was produced any other legitimate way.

Reproduced off-device against the repo's real bip32/bip39:

| Scenario | Old result |
|---|---|
| Standard seed, no passphrase, standard path | ✅ match |
| Seed uses a **BIP39 passphrase** (passphrase never passed) | ❌ "not part of" |
| Cosigner at a **per-cosigner / non-zero account path** (global path used) | ❌ "not part of" |
| `wsh(sortedmulti(...))` **descriptor** (global path stays `''`) | ❌ throws `Expected BIP32Path` |

This is a false rejection — the customer's backup is valid; nothing is lost. With the fix they re-import the same config and it works.

## Fix

- **`class/multisig-cosigner-match.ts`** (new, DFX-owned): `findCosignerIndexForSeed(wallet, mnemonic, passphrase)` matches by **master fingerprint** first (robust regardless of path/passphrase/encoding), then falls back to deriving the xpub at **each cosigner's own path** with the passphrase — the same derivation BlueWallet uses internally. Kept **out** of `MultisigHDWallet` so that BlueWallet-derived class stays byte-identical to upstream and doesn't conflict on fork sync.
- Import screen uses the helper and passes the wallet's **actual passphrase** into `replaceCosignerXpubWithSeed` (was hardcoded `''`).
- 5 regression tests covering all scenarios above.
- Add `__mocks__/react-native-config.js` — the `react-native-config` import added in #171 had no jest mock, which broke unit-suite loading.

## Why no change to `multisig-hd-wallet.js`

Checked the BlueWallet upstream source: it has **no** seed→cosigner matcher (this check is DFX-specific), and its `sortedmulti()` parser **intentionally** leaves the global derivation path empty — per-cosigner paths are authoritative everywhere downstream. So the descriptor "throw" only came from the DFX *screen* deriving at the bare global path; matching via per-cosigner paths (as upstream does) removes it **without** touching shared parsing. No back-fill, no shared-class edit.

## Tests

`multisig-hd-wallet` unit suite green (16/16, incl. 5 new). New helper has no tsc/eslint/prettier findings; no new errors vs. baseline elsewhere.

> Note: this PR targets the fork's `develop` for review visibility, not upstream.