### PR TITLE
Add multisig diagnostics to the self-test screen

### DIFF
--- a/screen/selftest.js
+++ b/screen/selftest.js
@@ -15,7 +15,9 @@ import {
   HDSegwitBech32Wallet,
   HDAezeedWallet,
   SLIP39LegacyP2PKHWallet,
+  MultisigHDWallet,
 } from '../class';
+import { findCosignerIndexForSeed } from '../class/multisig-cosigner-match';
 import ecc from '../blue_modules/noble_ecc';
 const bitcoin = require('bitcoinjs-lib');
 const BlueCrypto = require('react-native-blue-crypto');
@@ -186,7 +188,12 @@ export default class Selftest extends Component {
           },
         ];
 
-        const txNew2 = wallet.createTransaction(utxos2, [{ value: 90000, address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }], 1, wallet.getAddress());
+        const txNew2 = wallet.createTransaction(
+          utxos2,
+          [{ value: 90000, address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }],
+          1,
+          wallet.getAddress(),
+        );
         const tx = bitcoin.Transaction.fromHex(txNew2.tx.toHex());
         assertStrictEqual(
           txNew2.tx.toHex(),
@@ -308,15 +315,163 @@ export default class Selftest extends Component {
 
       if (isRN) {
         await step('Linking.canOpenURL(https)', async () => {
-          assertStrictEqual(
-            await Linking.canOpenURL('https://github.com/BlueWallet/BlueWallet/'),
-            true,
-            'Linking can not open https url',
-          );
+          assertStrictEqual(await Linking.canOpenURL('https://github.com/BlueWallet/BlueWallet/'), true, 'Linking can not open https url');
         });
       } else {
         log('- Linking: skipped (not RN)');
       }
+
+      await step('MultisigHDWallet P2WSH (native segwit) 2-of-3 create + fully sign tx', async () => {
+        const { wallet, address, psbt, tx } = buildSignedMultisig('native');
+        assertStrictEqual(address, 'bc1qqxuxfjvqcwyz3anmdptgj3rtas5c0w6h9p0yanqqx2yz0s25ceaqv9m44p', 'multisig native address');
+        assertStrictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2, 'multisig native sig count');
+        assertStrictEqual(!!tx, true, 'multisig native tx not finalized');
+        assertStrictEqual(
+          tx.toHex(),
+          '02000000000101674858a6180c3b8de3ff97c99118a43cc282d18d756b5b53aa8d70d673b52e9300000000000000008002905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac582600000000000022002035fa0b090f91f329cd5d96af493d593d0f454a8e8012526f8dcd5887e297ab0a0400483045022100b46ca1f3b336b0dcdd9304dbae7356de12b41ccd362206578e4fcbeb5976a2380220639b2de612084ca4880412452a8652e05070766b5884497e566b86cf85b98cbf0147304402205674ca71e69475a603b0470abd2b6e9b4715c28ddd44c93664adab033a1c49da022047aa6866fb08d6c68035b3e20d9f12453afaddd683ce3a8c72b02fb33801843001695221027ea237a4bcce5a375de67f7a094f5e9ab4fc466390e8f56658ed1c44488f84c82103d28f7015d5091c6a0dd4d84ff85c59eaf6d8d6795559da446eb2602fade078852103dc1953c2756c7c58d4f48ca1bbba767f414fd236bf4d662b67721ac626c514e053ae00000000',
+          'multisig native tx hex',
+        );
+        const parsed = bitcoin.Transaction.fromHex(tx.toHex());
+        assertStrictEqual(parsed.ins.length, 1, 'multisig native inputs');
+        assertStrictEqual(parsed.outs.length, 2, 'multisig native outputs');
+        assertStrictEqual(
+          bitcoin.address.fromOutputScript(parsed.outs[0].script),
+          '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB',
+          'multisig native recipient',
+        );
+      });
+
+      await step('MultisigHDWallet P2SH-P2WSH (wrapped segwit) 2-of-3 create + fully sign tx', async () => {
+        const { wallet, address, psbt, tx } = buildSignedMultisig('wrapped');
+        assertStrictEqual(address, '3HF9PMvQvRgcjN54XXdLAJf8BF34txtd3t', 'multisig wrapped address');
+        assertStrictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2, 'multisig wrapped sig count');
+        assertStrictEqual(!!tx, true, 'multisig wrapped tx not finalized');
+        assertStrictEqual(
+          tx.toHex(),
+          '02000000000101c1d353f3fd6ae4462a2a577c6a6727569d054d43c39e7ea71e4083d519160ccb00000000232200209ef56844d943322c25447dcfb149070a1b1973b323e75f4f2f386ca54aea5eb50000008002905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac352600000000000017a91415d70ea28b1cc1714e0e18731ce85ecd7e4d31cd870400483045022100896c0b63e70d0bfb5892a244cfb9f7d7d20afe6422cc1ed1bca842f0987f8e9a02207298445a94942fb0a78a9d9cb3c7bea782ce86e3c62da3b146d17064cd15eca4014730440220496cddc837802f1a5a2f22094822d1b90ce9d76b3687e8f325451fe8100204340220565c0d2ea63bfb8737e5d9cdbdb38bd331ec57f8ad05c17dc61bd2664f63f7b90169522102b373a8edcc14f4ba3276635e6c9ac782202aa327e8de8a4618f8063f569324152103abe5ccc0a6ddf20e02e27ca4829a4bcf288849f5d137db19559dd2ab23236dbe2103ad59934d6296d1041357fe385a82b0d55d50fbfd8fad4ea6729b583c9294a21253ae00000000',
+          'multisig wrapped tx hex',
+        );
+        const parsed = bitcoin.Transaction.fromHex(tx.toHex());
+        assertStrictEqual(parsed.ins.length, 1, 'multisig wrapped inputs');
+        assertStrictEqual(parsed.outs.length, 2, 'multisig wrapped outputs');
+        assertStrictEqual(
+          bitcoin.address.fromOutputScript(parsed.outs[0].script),
+          '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB',
+          'multisig wrapped recipient',
+        );
+      });
+
+      await step('MultisigHDWallet P2SH (legacy) 2-of-3 create + fully sign tx', async () => {
+        const { wallet, address, psbt, tx } = buildSignedMultisig('legacy');
+        assertStrictEqual(address, '37xAGrCeryNrNo6hSUxHQM6KqddrpY79vh', 'multisig legacy address');
+        assertStrictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2, 'multisig legacy sig count');
+        assertStrictEqual(!!tx, true, 'multisig legacy tx not finalized');
+        assertStrictEqual(
+          tx.toHex(),
+          '0200000001244e9b60cd50fc2e3d5effa0928928500160eb41439006b7b2a58f7410c9e7b000000000fdfe0000483045022100fe90a753908be0664041f6d097ffae2a06b9fdd857ebc9e8d4265195beecb524022017129a95d83923b8af6554b736b1fd8df45223f31d47f1202541b7f2f483e3550148304502210085970b3703d1f85c1e91ed39040f2a13e9b75c1a3cbadaeaf5891af71dc5b23f022059ae19e8ee187329430664b6be2e69b799ece6cbe87ffe4bc85a2a1450708cf6014c69522102928ce56c258522767df7385d9a5f4beaf599d310f52b510a4cf01c762749bb7a21034c2273445591185bb37ebb08010d53e85c3791e3fa56c1756284fdf17206a0102103bf9331688d29fff59100b437d3bdf4f14a671b1da13ce57d01eb5d109ab5d1c053ae0000008002905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac962500000000000017a914d48975225be4992d7cb576744a72e64b7ad6713e8700000000',
+          'multisig legacy tx hex',
+        );
+        const parsed = bitcoin.Transaction.fromHex(tx.toHex());
+        assertStrictEqual(parsed.ins.length, 1, 'multisig legacy inputs');
+        assertStrictEqual(parsed.outs.length, 2, 'multisig legacy outputs');
+        assertStrictEqual(
+          bitcoin.address.fromOutputScript(parsed.outs[0].script),
+          '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB',
+          'multisig legacy recipient',
+        );
+      });
+
+      await step('MultisigHDWallet 2-of-3 single-device partial sign (1 of 2)', async () => {
+        // realistic case: this device holds only its own seed; the other two cosigners are xpubs.
+        // it can contribute one signature and must hand the PSBT to a second signer to finalize.
+        const w = new MultisigHDWallet();
+        w.setNativeSegwit();
+        w.setDerivationPath(MULTISIG_PATHS.native);
+        w.addCosigner(MULTISIG_SEED_1);
+        w.addCosigner(
+          MultisigHDWallet.seedToXpub(MULTISIG_SEED_2, MULTISIG_PATHS.native),
+          MultisigHDWallet.mnemonicToFingerprint(MULTISIG_SEED_2, ''),
+        );
+        w.addCosigner(
+          MultisigHDWallet.seedToXpub(MULTISIG_SEED_3, MULTISIG_PATHS.native),
+          MultisigHDWallet.mnemonicToFingerprint(MULTISIG_SEED_3, ''),
+        );
+        w.setM(2);
+        assertStrictEqual(
+          w._getExternalAddressByIndex(0),
+          'bc1qqxuxfjvqcwyz3anmdptgj3rtas5c0w6h9p0yanqqx2yz0s25ceaqv9m44p',
+          'multisig partial address',
+        );
+        const { psbt, tx } = fundAndSpendMultisig(w);
+        assertStrictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1, 'multisig partial sig count');
+        assertStrictEqual(psbt.data.inputs[0].partialSig.length, 1, 'multisig partial partialSig');
+        assertStrictEqual(!!tx, false, 'multisig partial must not be finalized');
+        assertStrictEqual(typeof psbt.toBase64(), 'string', 'multisig partial PSBT serializable');
+      });
+
+      await step('MultisigHDWallet export/import round-trip preserves addresses', async () => {
+        const { wallet } = buildSignedMultisig('native');
+        const imported = new MultisigHDWallet();
+        imported.setSecret(wallet.getSecret());
+        assertStrictEqual(imported._getExternalAddressByIndex(0), wallet._getExternalAddressByIndex(0), 'multisig round-trip external');
+        assertStrictEqual(imported._getInternalAddressByIndex(0), wallet._getInternalAddressByIndex(0), 'multisig round-trip internal');
+      });
+
+      await step('MultisigHDWallet 2-of-3 cosigner with BIP39 passphrase -> address', async () => {
+        const w = new MultisigHDWallet();
+        w.setDerivationPath("m/48'/0'/0'/2'");
+        w.addCosigner(
+          'salon smoke bubble dolphin powder govern rival sport better arrest certain manual',
+          undefined,
+          undefined,
+          '9WDdFSZX4d6mPxkr',
+        );
+        w.addCosigner('chaos word void picture gas update shop wave task blossom close inner', undefined, undefined, 'E5jMAzsf464Hgwns');
+        w.addCosigner(
+          'plate inform scissors pill asset scatter people emotion dose primary together expose',
+          undefined,
+          undefined,
+          'RyBFfLr7weK3nDUG',
+        );
+        w.setM(2);
+        assertStrictEqual(
+          w._getExternalAddressByIndex(0),
+          'bc1q8rks34ypj5edxx82f7z7yzy4qy6dynfhcftjs9axzr2ml37p4pfs7j4uvm',
+          'multisig passphrase address',
+        );
+      });
+
+      await step('MultisigHDWallet custom per-cosigner derivation paths -> address', async () => {
+        const secret =
+          '# CoboVault Multisig setup file (created on D37EAD88)\n#\nName: CV_33B5B91A_2-2\nPolicy: 2 of 2\nFormat: P2WSH\n\n' +
+          "# derivation: m/47'/0'/0'/1'\n" +
+          'D37EAD88: Zpub74ijpfhERJNjhCKXRspTdLJV5eoEmSRZdHqDvp9kVtdVEyiXk7pXxRbfZzQvsDFpfDHEHVtVpx4Dz9DGUWGn2Xk5zG5u45QTMsYS2vjohNQ\n\n' +
+          "# derivation: m/46'/0'/0'/1'\n" +
+          '168DD603: Zpub75mAE8EjyxSzoyPmGnd5E6MyD7ALGNndruWv52xpzimZQKukwvEfXTHqmH8nbbc6ccP5t2aM3mws3pKYSnKpKMMytdbNEZFUxKzztYFM8Pn\n';
+        const w = new MultisigHDWallet();
+        w.setSecret(secret);
+        assertStrictEqual(w.getCustomDerivationPathForCosigner(1), "m/47'/0'/0'/1'", 'multisig custom path 1');
+        assertStrictEqual(w.getCustomDerivationPathForCosigner(2), "m/46'/0'/0'/1'", 'multisig custom path 2');
+        assertStrictEqual(
+          w._getExternalAddressByIndex(0),
+          'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85',
+          'multisig custom-path address',
+        );
+      });
+
+      await step('Multisig cosigner match: own seed recognised in xpub-only config', async () => {
+        const source = buildSignedMultisig('native').wallet;
+        const config = new MultisigHDWallet();
+        config.setSecret(source.getXpub()); // public coordination setup, no private keys
+        assertStrictEqual(findCosignerIndexForSeed(config, MULTISIG_SEED_1), 1, 'cosigner match seed 1');
+        assertStrictEqual(findCosignerIndexForSeed(config, MULTISIG_SEED_2), 2, 'cosigner match seed 2');
+        assertStrictEqual(findCosignerIndexForSeed(config, MULTISIG_SEED_3), 3, 'cosigner match seed 3');
+        assertStrictEqual(
+          findCosignerIndexForSeed(config, 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art'),
+          -1,
+          'cosigner match rejects stranger',
+        );
+      });
 
       log(`all tests passed in ${Date.now() - tStart}ms`);
     } catch (Err) {
@@ -402,6 +557,50 @@ export default class Selftest extends Component {
       </SafeBlueArea>
     );
   }
+}
+
+const MULTISIG_SEED_1 = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const MULTISIG_SEED_2 = 'chaos word void picture gas update shop wave task blossom close inner';
+const MULTISIG_SEED_3 = 'plate inform scissors pill asset scatter people emotion dose primary together expose';
+const MULTISIG_PATHS = { native: "m/48'/0'/0'/2'", wrapped: "m/48'/0'/0'/1'", legacy: "m/45'" };
+
+function setMultisigFormat(w, kind) {
+  if (kind === 'native') w.setNativeSegwit();
+  else if (kind === 'wrapped') w.setWrappedSegwit();
+  else w.setLegacy();
+}
+
+// funds a multisig wallet with a synthetic prev-tx and spends it (so signing needs no network)
+function fundAndSpendMultisig(w) {
+  const address = w._getExternalAddressByIndex(0);
+  const funding = new bitcoin.Transaction();
+  funding.addInput(Buffer.from('00'.repeat(32), 'hex'), 0);
+  funding.addOutput(bitcoin.address.toOutputScript(address, bitcoin.networks.bitcoin), 100000);
+  const utxos = [{ txId: funding.getId(), txid: funding.getId(), vout: 0, value: 100000, address, txhex: funding.toHex() }];
+  const { psbt, tx } = w.createTransaction(
+    utxos,
+    [{ address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', value: 90000 }],
+    1,
+    w._getInternalAddressByIndex(0),
+    false,
+    false,
+  );
+  return { address, psbt, tx };
+}
+
+// 2-of-3 (the wallet's default policy) holding 2 seeds + 1 watch-only cosigner -> fully signs
+function buildSignedMultisig(kind) {
+  const w = new MultisigHDWallet();
+  setMultisigFormat(w, kind);
+  w.setDerivationPath(MULTISIG_PATHS[kind]); // must precede addCosigner() for seed cosigners
+  w.addCosigner(MULTISIG_SEED_1);
+  w.addCosigner(MULTISIG_SEED_2);
+  w.addCosigner(
+    MultisigHDWallet.seedToXpub(MULTISIG_SEED_3, MULTISIG_PATHS[kind]),
+    MultisigHDWallet.mnemonicToFingerprint(MULTISIG_SEED_3, ''),
+  );
+  w.setM(2);
+  return { wallet: w, ...fundAndSpendMultisig(w) };
 }
 
 function assertStrictEqual(actual, expected, message) {


### PR DESCRIPTION
Adds multisig coverage to the self-test screen (`screen/selftest.js`), which previously tested only single-sig wallets.

⚠️ **Depends on PR #177** (`fix/multisig-cosigner-match-issue-176`). Based on `develop`, so the cosigner-match step's `import { findCosignerIndexForSeed }` does not resolve until #177 is merged into `develop` — the bundle/CI is intentionally red until then. Merge #177 first.

## Steps added (all deterministic, no network)

Built for the wallet's **default 2-of-3** policy:

- **P2WSH / P2SH-P2WSH / P2SH 2-of-3** — create + fully sign + finalize, assert exact tx hex (holds 2 seeds + 1 watch-only xpub).
- **2-of-3 single-device partial sign (1 of 2)** — holds one seed, the other two are xpubs → one partial signature, not finalized, PSBT serializable for the next signer (the common DFX flow).
- **Export/import round-trip** preserves addresses.
- **Cosigner with BIP39 passphrase** → address.
- **Custom per-cosigner derivation paths** → address.
- **Cosigner match** — own seed recognised in an xpub-only config (exercises #177's fix).

## Fixtures

Wallets are derived from public test mnemonics; expected tx hexes were generated from the wallet code and baked as regression anchors. Passphrase / custom-path address vectors are reused from existing unit tests.

## Still TODO (separate commit)

An **Electrum network** diagnostic anchored to a real (now-empty) multisig: assert a known confirmed txid is part of its history (drift-proof) and that the setup validates/cosigns a stored PSBT.