### PR TITLE
selftest: gate live-network multisig check behind __DEV__

### DIFF
--- a/screen/selftest.js
+++ b/screen/selftest.js
@@ -503,7 +503,7 @@ export default class Selftest extends Component {
         assertStrictEqual(partialSig[0].signature.toString('hex'), REAL_WITHDRAW_SIG, 'reproduces the real cosigner-3 signature');
       });
 
-      if (isRN) {
+      if (isRN && __DEV__) {
         await step('Multisig real wallet: Electrum sees the on-chain withdrawal', async () => {
           await BlueElectrum.waitTillConnected();
           // confirmed tx -> stays in history forever even though the wallet is now empty (drift-proof)
@@ -512,7 +512,7 @@ export default class Selftest extends Component {
           if (!found) throw new Error('withdrawal tx not found in multisig address history');
         });
       } else {
-        log('- Multisig Electrum history: skipped (not RN)');
+        log('- Multisig Electrum history: skipped (live-network, __DEV__ only)');
       }
 
       log(`all tests passed in ${Date.now() - tStart}ms`);


### PR DESCRIPTION
Stacked on #179 — addresses TaprootFreak's review (https://github.com/DFXswiss/btc-wallet/pull/179#issuecomment-4742143378).

## What
Gate the **live-network** multisig self-test step behind `__DEV__`:

```diff
-      if (isRN) {
+      if (isRN && __DEV__) {
         await step('Multisig real wallet: Electrum sees the on-chain withdrawal', ...)
```

In a release build, that step did `BlueElectrum.waitTillConnected()` + an on-chain `getTransactionsByAddress` on every run, so a user-triggered self test could hang on a slow/unreachable Electrum server. It now runs in `__DEV__` only.

## What stays in release
The offline, deterministic multisig diagnostics keep running in all builds: create/sign/finalize across P2WSH/P2SH-P2WSH/P2SH, the real-withdrawal **reconstruct + signature match** (no network), cosigner-match, and export/import round-trip.

## Notes for the reviewer
- The seed used by the real-wallet step is a **throwaway vault** (no funds, deliberately burned), so committing it is not a key leak — happy to also move it (and the offline real-wallet step) behind `__DEV__` if you'd prefer release builds touch nothing real.
- The always-available Selftest entry (About screen, every build) is pre-existing upstream BlueWallet behavior, not introduced here.
- `__DEV__` matches existing repo usage (`blue_modules/notifications.ts`, `shim.js`). prettier + eslint clean on the changed file.

Once #179 merges to `develop`, this can be retargeted to `develop`.